### PR TITLE
Potential fix for code scanning alert no. 2: DOM text reinterpreted as HTML

### DIFF
--- a/html/script.js
+++ b/html/script.js
@@ -62,7 +62,7 @@ function loadEnvironments() {
                 
                 option = document.createElement("option")
                 option.value = environment
-                option.innerHTML = environment
+                option.textContent = environment
                 envSelect.appendChild(option)
             }
              // make sure we have set the postback url:


### PR DESCRIPTION
Potential fix for [https://github.com/rajbos/create-github-app-from-manifest/security/code-scanning/2](https://github.com/rajbos/create-github-app-from-manifest/security/code-scanning/2)

To fix this problem, avoid setting user-controlled or potentially untrusted values as HTML content via `.innerHTML`. Instead, use `.textContent` (or `.innerText`) on the created `<option>` element. This property sets only the text within the element, escaping any special HTML characters. The fix should be made at line 65 in `html/script.js`, changing `option.innerHTML = environment` to `option.textContent = environment`. No other changes are required, and no imports are necessary.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
